### PR TITLE
Attempt at fixing encoding bug

### DIFF
--- a/src/PayFast/Base/PayFastBase.cs
+++ b/src/PayFast/Base/PayFastBase.cs
@@ -133,7 +133,7 @@
 
             var md5 = MD5.Create();
 
-            var inputBytes = Encoding.ASCII.GetBytes(inputStringBuilder.ToString());
+            var inputBytes = Encoding.UTF8.GetBytes(inputStringBuilder.ToString());
 
             var hash = md5.ComputeHash(inputBytes);
 

--- a/src/PayFast/Base/PayFastBase.cs
+++ b/src/PayFast/Base/PayFastBase.cs
@@ -112,15 +112,8 @@
 
         protected string UrlEncode(string url)
         {
-            Dictionary<string, string> convertPairs = new Dictionary<string, string>() { { "%", "%25" }, { "!", "%21" }, { "#", "%23" }, { " ", "+" },
-            { "$", "%24" }, { "&", "%26" }, { "'", "%27" }, { "(", "%28" }, { ")", "%29" }, { "*", "%2A" }, { "+", "%2B" }, { ",", "%2C" },
-            { "/", "%2F" }, { ":", "%3A" }, { ";", "%3B" }, { "=", "%3D" }, { "?", "%3F" }, { "@", "%40" }, { "[", "%5B" }, { "]", "%5D" } };
 
-            var replaceRegex = new Regex(@"[%!# $&'()*+,/:;=?@\[\]]");
-            MatchEvaluator matchEval = match => convertPairs[match.Value];
-            string encoded = replaceRegex.Replace(url, matchEval);
-
-            return encoded;
+            return System.Net.WebUtility.UrlEncode(url.Trim()); 
         }
 
         protected string CreateHash(StringBuilder input)

--- a/src/PayFast/Base/PayFastBase.cs
+++ b/src/PayFast/Base/PayFastBase.cs
@@ -65,7 +65,7 @@
             {
                 var currentEnumValue = propertyInfo.GetValue(this, null);
 
-                if(currentEnumValue == null)
+                if (currentEnumValue == null)
                 {
                     return string.Empty;
                 }
@@ -81,7 +81,7 @@
                 {
                     var booleanValue = (bool?)propertyInfo.GetValue(this, null);
 
-                    return booleanValue.HasValue ?  booleanValue.Value ? "1" : "0" : string.Empty;
+                    return booleanValue.HasValue ? booleanValue.Value ? "1" : "0" : string.Empty;
                 }
                 else
                 {
@@ -93,7 +93,7 @@
 
             if (propertyInfo.PropertyType.IsAssignableFrom(typeof(DateTime)))
             {
-                if(propertyInfo.PropertyType == typeof(DateTime?))
+                if (propertyInfo.PropertyType == typeof(DateTime?))
                 {
                     var dateTimeValue = (DateTime?)propertyInfo.GetValue(this, null);
 
@@ -112,8 +112,15 @@
 
         protected string UrlEncode(string url)
         {
-
-            return System.Net.WebUtility.UrlEncode(url.Trim()); 
+            string encoded =  System.Net.WebUtility.UrlEncode(url.Trim());
+            
+            //Fix for .NET missing out some characaters when encoding
+            StringBuilder sb = new StringBuilder(encoded);
+            return sb
+                  .Replace("(", "%28")
+                  .Replace(")", "%29")
+                  .Replace("!", "%21")
+                  .ToString();
         }
 
         protected string CreateHash(StringBuilder input)

--- a/src/PayFast/Extensions/StringBuilderExtensions.cs
+++ b/src/PayFast/Extensions/StringBuilderExtensions.cs
@@ -10,7 +10,7 @@
 
             var md5 = MD5.Create();
 
-            var inputBytes = Encoding.ASCII.GetBytes(inputStringBuilder.ToString());
+            var inputBytes = Encoding.UTF8.GetBytes(inputStringBuilder.ToString());
 
             var hash = md5.ComputeHash(inputBytes);
 

--- a/src/PayFast/Extensions/StringExtensions.cs
+++ b/src/PayFast/Extensions/StringExtensions.cs
@@ -1,21 +1,22 @@
 ﻿namespace System
 {
     using System.Collections.Generic;
+    using System.Text;
     using System.Text.RegularExpressions;
 
     public static class StringExtensions
     {
         public static string UrlEncode(this string url)
         {
-            Dictionary<string, string> convertPairs = new Dictionary<string, string>() { { "%", "%25" }, { "!", "%21" }, { "#", "%23" }, { " ", "+" },
-            { "$", "%24" }, { "&", "%26" }, { "'", "%27" }, { "(", "%28" }, { ")", "%29" }, { "*", "%2A" }, { "+", "%2B" }, { ",", "%2C" },
-            { "/", "%2F" }, { ":", "%3A" }, { ";", "%3B" }, { "=", "%3D" }, { "?", "%3F" }, { "@", "%40" }, { "[", "%5B" }, { "]", "%5D" } };
+            string encoded = System.Net.WebUtility.UrlEncode(url.Trim());
 
-            var replaceRegex = new Regex(@"[%!# $&'()*+,/:;=?@\[\]]");
-            MatchEvaluator matchEval = match => convertPairs[match.Value];
-            string encoded = replaceRegex.Replace(url, matchEval);
-
-            return encoded;
+            //Fix for .NET missing out some characaters when encoding
+            StringBuilder sb = new StringBuilder(encoded);
+            return sb
+                  .Replace("(", "%28")
+                  .Replace(")", "%29")
+                  .Replace("!", "%21")
+                  .ToString();
         }
     }
 }

--- a/test/PayFast.UnitTests/RequestTests.cs
+++ b/test/PayFast.UnitTests/RequestTests.cs
@@ -133,5 +133,36 @@
             // Assert
             Assert.Equal("66d25171083fa3e36ff3ebaa3c7f0713", signature);
         }
+		
+		
+
+        [Fact]
+        public void Can_Generate_Correct_Signature_With_Foreign_Characters()
+        {
+            // Arrange
+            var onceOffRequest = new PayFastRequest();
+
+            // Merchant Details
+            onceOffRequest.merchant_id = "10000100";
+            onceOffRequest.merchant_key = "46f0cd694581a";
+            onceOffRequest.return_url = "https://5ca4377c.ngrok.io/home/return";
+            onceOffRequest.cancel_url = "https://5ca4377c.ngrok.io/home/cancel";
+            onceOffRequest.notify_url = "https://5ca4377c.ngrok.io/home/notify";
+
+            // Buyer Details
+            onceOffRequest.email_address = "sbtu01@payfast.co.za";
+
+            // Transaction Details
+            onceOffRequest.m_payment_id = "8d00bf49-e979-4004-228c-08d452b86380";
+            onceOffRequest.amount = 30;
+            onceOffRequest.item_name = "Foreign Çhåractérs";
+            onceOffRequest.item_description = "Some details about the once off payment";
+
+            // Act
+            var signature = onceOffRequest.signature;
+
+            // Assert
+            Assert.Equal("c83013dd7ff3e7c4b0917b2af6e4bfcc", signature);
+        }
     }
 }


### PR DESCRIPTION
The problem actually seems to arise from the UrlEncode method. Switching to a native .NET method instead. Basic testing in dotnetfiddle shows this should work: https://dotnetfiddle.net/6v8xtx, as I'm getting same results as in PHP. However testing those changes with my PayFast implementation failed. I couldn't get the unit tests to load so couldn't test conclusively.