### PR TITLE
Validator SSL Fix

### DIFF
--- a/src/PayFast/PayFastValidator.cs
+++ b/src/PayFast/PayFastValidator.cs
@@ -119,6 +119,8 @@
                 {
                     using (var webClient = new HttpClient())
                     {
+                        //Forces use of higher ssl. Connection was being forcibly closed on the payfast sandbox when attempting to validate.
+                        System.Net.ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
                         using (var response = await webClient.PostAsync(this.Settings.ValidateUrl, formContent))
                         {
                             if (response.IsSuccessStatusCode)


### PR DESCRIPTION
Updated the PayFastValidator.cs to include higher ssl validation when validating the data model back to PayFast. 

Was getting a 502: Connection forcibly closed from the sandbox when attempting to validate with the default code and default ssl handling.