### PR TITLE
Add support for m_payment_id in PayFastAdHoc.Charge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ The latest version is 1.0.4.
 * .Net 4.6
 * .Net 4.6.1
 * .Net 4.6.2
-* .Net Standard 1.6
 * .Net Standard 2.0
 
 # Supported Request Types

--- a/src/PayFast.AspNetCore/PayFast.AspNetCore.csproj
+++ b/src/PayFast.AspNetCore/PayFast.AspNetCore.csproj
@@ -10,23 +10,15 @@
     <PackageLicenseUrl>https://github.com/louislewis2/payfast/blob/master/License.md</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/louislewis2/payfast</RepositoryUrl>
-    <TargetFrameworks>netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageReleaseNotes>Add Netstandard 2.0 Support</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/louislewis2/payfast</PackageProjectUrl>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6'">
-    <DefineConstants>COREFX;NETCORE;NETSTANDARD;NETSTANDARD1_6</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
     <DefineConstants>COREFX;NETCORE;NETSTANDARD;NETSTANDARD2_0</DefineConstants>
   </PropertyGroup>
   
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="1.1.3" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.0.0" />
   </ItemGroup>

--- a/src/PayFast/PayFast.csproj
+++ b/src/PayFast/PayFast.csproj
@@ -4,7 +4,7 @@
     <Description>PayFast Integration Library</Description>
     <VersionPrefix>1.0.5</VersionPrefix>
     <Authors>Louis Lewis</Authors>
-    <TargetFrameworks>net45;net451;net452;net46;net461;net462;netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net45;net451;net452;net46;net461;net462;netstandard2.0</TargetFrameworks>
     <AssemblyName>PayFast</AssemblyName>
     <PackageId>PayFast</PackageId>
     <PackageTags>PayFast;PayFast Integration</PackageTags>

--- a/src/PayFast/PayFastSettings.cs
+++ b/src/PayFast/PayFastSettings.cs
@@ -1,4 +1,6 @@
-﻿namespace PayFast
+﻿using System.Reflection;
+
+namespace PayFast
 {
     public class PayFastSettings
     {
@@ -14,5 +16,21 @@
         public string NotifyUrl { get; set; }
 
         #endregion Properties
+
+        /// <summary>
+        /// Creates a copy of the current PayFastSettings instance.
+        /// </summary>
+        public virtual PayFastSettings Clone()
+        {
+            PayFastSettings pfsCopy = new PayFastSettings();
+            foreach (var prop in this.GetType().GetProperties())
+            {
+                PropertyInfo propInfo = pfsCopy.GetType().GetProperty(prop.Name);
+                var propValue = prop.GetValue(this, null);
+                propInfo.SetValue(pfsCopy, prop.GetValue(this, null), null);
+            }
+
+            return pfsCopy;
+        }
     }
 }


### PR DESCRIPTION
The current implementation does not support passing the `m_payment_id` parameter when performing an AdHoc tokenized charge.